### PR TITLE
fix `ssh: must specify HostKeyCallback`

### DIFF
--- a/stability-tester/cluster/ssh_node.go
+++ b/stability-tester/cluster/ssh_node.go
@@ -61,6 +61,7 @@ func (s *sshNode) createClient() *ssh.Client {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
 	addr := fmt.Sprintf("%s:%d", s.host, s.port)


### PR DESCRIPTION
Golang now requires specifying HostKeyCallback (https://github.com/golang/go/issues/19767).