### PR TITLE
Provide more detailed errors when DDL test fail

### DIFF
--- a/stability-tester/ddl/ddl.go
+++ b/stability-tester/ddl/ddl.go
@@ -264,7 +264,7 @@ func (c *testCase) executeVerifyIntegrity() error {
 			}
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 		}
 
 		// Read all rows.
@@ -335,16 +335,16 @@ func (c *testCase) executeVerifyIntegrity() error {
 			}
 			_, ok := actualRowsMap[rowString]
 			if !ok {
-				return errors.Trace(fmt.Errorf("Expecting row %s in table `%s` but not found", rowString, table.name))
+				return errors.Trace(fmt.Errorf("Expecting row %s in table `%s` but not found, sql: ", rowString, table.name, sql))
 			}
 			actualRowsMap[rowString]--
 			if actualRowsMap[rowString] < 0 {
-				return errors.Trace(fmt.Errorf("Expecting row %s in table `%s` but not found", rowString, table.name))
+				return errors.Trace(fmt.Errorf("Expecting row %s in table `%s` but not found, sql: ", rowString, table.name, sql))
 			}
 		}
 		for rowString, occurs := range actualRowsMap {
 			if occurs > 0 {
-				return errors.Trace(fmt.Errorf("Unexpected row %s in table `%s`", rowString, table.name))
+				return errors.Trace(fmt.Errorf("Unexpected row %s in table `%s`, sql: ", rowString, table.name, sql))
 			}
 		}
 	}
@@ -367,7 +367,7 @@ func (c *testCase) executeAdminCheck() error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s", sql)
 	}
 	return nil
 }

--- a/stability-tester/ddl/ddl_ops.go
+++ b/stability-tester/ddl/ddl_ops.go
@@ -320,7 +320,7 @@ func (c *testCase) executeAddColumn(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Annotatef(err, "Error when executing SQL: %s", sql)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	// update table definitions

--- a/stability-tester/ddl/ddl_ops.go
+++ b/stability-tester/ddl/ddl_ops.go
@@ -100,7 +100,7 @@ func (c *testCase) executeAddTable(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, tableInfo.debugPrintToString())
 	}
 
 	c.tablesLock.Lock()
@@ -130,7 +130,7 @@ func (c *testCase) executeDropTable(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s", sql)
 	}
 
 	return nil
@@ -216,7 +216,7 @@ func (c *testCase) executeAddIndex(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	table.indexes = append(table.indexes, &index)
@@ -252,7 +252,7 @@ func (c *testCase) executeDropIndex(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	for _, column := range indexToDrop.columns {
@@ -320,7 +320,7 @@ func (c *testCase) executeAddColumn(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s", sql)
 	}
 
 	// update table definitions
@@ -393,7 +393,7 @@ func (c *testCase) executeDropColumn(cfg interface{}) error {
 	log.Infof("[ddl] [instance %d] %s", c.caseIndex, sql)
 	_, err := c.db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	// update table definitions

--- a/stability-tester/ddl/dml_ops.go
+++ b/stability-tester/ddl/dml_ops.go
@@ -190,7 +190,7 @@ func (c *testCase) executeInsert(cfg interface{}) error {
 				return ddlTestErrorConflict{}
 			}
 		}
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	// append row
@@ -361,7 +361,7 @@ func (c *testCase) executeUpdate(cfg interface{}) error {
 				return ddlTestErrorConflict{}
 			}
 		}
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	// update values
@@ -445,7 +445,7 @@ func (c *testCase) executeDelete(cfg interface{}) error {
 				return ddlTestErrorConflict{}
 			}
 		}
-		return errors.Trace(err)
+		return errors.Annotatef(err, "Error when executing SQL: %s\n%s", sql, table.debugPrintToString())
 	}
 
 	// update values


### PR DESCRIPTION
1. Print the SQL that cased the error. Don't need to trace the SQL from stack trace any more.

2. Print the **expected** table structure **before** executing the SQL, for better debugging.