### PR TITLE
Support TLS connection in raw:// and tikv:// protocol for ycsb

### DIFF
--- a/ycsb/coprocessor.go
+++ b/ycsb/coprocessor.go
@@ -154,9 +154,10 @@ func (c *coprocessor) ReadRow(key uint64) (has bool, err error) {
 	if err != nil {
 		return
 	}
-	res := client.Send(goctx.Background(), &req)
+	goCtx := goctx.Background()
+	res := client.Send(goCtx, &req)
 	defer res.Close()
-	data, err := res.Next()
+	data, err := res.Next(goCtx)
 	return len(data) != 0, err
 }
 

--- a/ycsb/main.go
+++ b/ycsb/main.go
@@ -53,6 +53,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/config"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -68,6 +69,9 @@ const (
 	zipfIMin = 1
 )
 
+var sslCa = flag.String("ssl-ca", "", "Acceptable Cluster CA path.")
+var sslCert = flag.String("ssl-cert", "", "Client certificate path.")
+var sslKey = flag.String("ssl-key", "", "Client certificate key path.")
 var concurrency = flag.Int("concurrency", 2*runtime.NumCPU(),
 	"Number of concurrent workers sending read/write requests.")
 var workload = flag.String("workload", "B", "workload type. Choose from A-F.")
@@ -341,6 +345,11 @@ func main() {
 		http.Handle("/metrics", prometheus.Handler())
 		http.ListenAndServe(*statusAddr, nil)
 	}()
+
+	cfg := config.GetGlobalConfig()
+	cfg.Security.ClusterSSLCA = *sslCa
+	cfg.Security.ClusterSSLCert = *sslCert
+	cfg.Security.ClusterSSLKey = *sslKey
 
 	PushMetrics(*pushAddr)
 

--- a/ycsb/raw.go
+++ b/ycsb/raw.go
@@ -60,7 +60,8 @@ func (c *rawKV) Clone() Database {
 func setupRawKV(pdAddr string) (Database, error) {
 	// Open connection to server and create a database.
 	tikv.MaxConnectionCount = 128
-	db, err := tikv.NewRawKVClient(strings.Split(pdAddr, ","), config.Security{})
+	security := config.GetGlobalConfig().Security
+	db, err := tikv.NewRawKVClient(strings.Split(pdAddr, ","), security)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
based on https://github.com/pingcap/octopus/pull/69

Usage:

```bash
ycsb -ssl-ca xxxx/cfssl/ca.pem --ssl-cert xxxx/cfssl/client.pem --ssl-key xxxx/cfssl/client-key.pem ........
```